### PR TITLE
Array properties support for graphml export/import

### DIFF
--- a/XmlGraphMLWriter.java
+++ b/XmlGraphMLWriter.java
@@ -1,0 +1,217 @@
+package org.neo4j.shell.tools.imp.format.graphml;
+
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.*;
+import org.neo4j.shell.tools.imp.util.Config;
+import org.neo4j.shell.tools.imp.util.MetaInformation;
+import org.neo4j.shell.tools.imp.util.Reporter;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.reflect.Array;
+import java.util.*;
+
+import static org.neo4j.shell.tools.imp.util.MetaInformation.getLabelsString;
+
+/**
+ * @author mh
+ * @since 21.01.14
+ */
+public class XmlGraphMLWriter {
+
+	public void write(SubGraph graph, Writer writer, Reporter reporter, Config config) throws IOException, XMLStreamException {
+		XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
+		XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);
+		writeHeader(xmlWriter);
+		if (config.useTypes()) writeKeyTypes(xmlWriter, graph);
+		for (Node node : graph.getNodes()) {
+			int props = writeNode(xmlWriter, node);
+			reporter.update(1, 0, props);
+		}
+		for (Relationship rel : graph.getRelationships()) {
+			int props = writeRelationship(xmlWriter, rel);
+			reporter.update(0, 1, props);
+		}
+		writeFooter(xmlWriter);
+	}
+
+	private void writeKeyTypes(XMLStreamWriter writer, SubGraph ops) throws IOException, XMLStreamException {
+		Map<String, Class> keyTypes = new HashMap<>();
+		for (Node node : ops.getNodes()) {
+			updateKeyTypes(keyTypes, node);
+		}
+		writeKeyTypes(writer, keyTypes, "node");
+		keyTypes.clear();
+		for (Relationship rel : ops.getRelationships()) {
+			updateKeyTypes(keyTypes, rel);
+		}
+		writeKeyTypes(writer, keyTypes, "edge");
+	}
+
+	private void writeKeyTypes(XMLStreamWriter writer, Map<String, Class> keyTypes, String forType) throws IOException, XMLStreamException {
+		for (Map.Entry<String, Class> entry : keyTypes.entrySet()) {
+
+			String type = MetaInformation.typeFor(entry.getValue(), MetaInformation.GRAPHML_ALLOWED);
+
+			if (type == null) continue;
+			writer.writeEmptyElement("key");
+			writer.writeAttribute("id", entry.getKey());
+			writer.writeAttribute("for", forType);
+			writer.writeAttribute("attr.name", entry.getKey());
+			writer.writeAttribute("attr.type", type);
+			newLine(writer);
+		}
+	}
+
+	private void updateKeyTypes(Map<String, Class> keyTypes, PropertyContainer pc) {
+		for (String prop : pc.getPropertyKeys()) {
+			Object value = pc.getProperty(prop);
+			Class storedClass = keyTypes.get(prop);
+
+			if (storedClass == null) {
+				keyTypes.put(prop, value.getClass());
+
+				continue;
+			}
+			if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
+			keyTypes.put(prop, void.class);
+		}
+	}
+
+	private int writeNode(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		writer.writeStartElement("node");
+		writer.writeAttribute("id", id(node));
+		writeLabels(writer, node);
+		writeLabelsAsData(writer, node);
+		int props = writeProps(writer, node);
+		endElement(writer);
+		return props;
+	}
+
+	private String id(Node node) {
+		return "n" + node.getId();
+	}
+
+	private void writeLabels(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		String labelsString = getLabelsString(node);
+		if (!labelsString.isEmpty()) writer.writeAttribute("labels", labelsString);
+	}
+
+	private void writeLabelsAsData(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		String labelsString = getLabelsString(node);
+		if (labelsString.isEmpty()) return;
+		writeData(writer, "labels", labelsString);
+	}
+
+	private int writeRelationship(XMLStreamWriter writer, Relationship rel) throws IOException, XMLStreamException {
+		writer.writeStartElement("edge");
+		writer.writeAttribute("id", id(rel));
+		writer.writeAttribute("source", id(rel.getStartNode()));
+		writer.writeAttribute("target", id(rel.getEndNode()));
+		writer.writeAttribute("label", rel.getType().name());
+		writeData(writer, "label", rel.getType().name());
+		int props = writeProps(writer, rel);
+		endElement(writer);
+		return props;
+	}
+
+	private String id(Relationship rel) {
+		return "e" + rel.getId();
+	}
+
+	private void endElement(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeEndElement();
+		newLine(writer);
+	}
+
+	// modified by gquercini to add array support
+	private int writeProps(XMLStreamWriter writer, PropertyContainer node) throws IOException, XMLStreamException {
+		int count = 0;
+		for (String prop : node.getPropertyKeys()) {
+			Object value = node.getProperty(prop);
+			Class valueClass = value.getClass();
+
+			if (valueClass.isArray()) 
+				writeArrayData(writer, prop, value); // added by gquercini to add array support
+			else
+				writeData(writer, prop, value);
+			count++;
+		}
+		return count;
+	}
+
+	// added by gquercini to add array support
+	private void writeArrayData(XMLStreamWriter writer, String prop, Object value) throws IOException, XMLStreamException {
+
+		if ( value == null ) return;
+
+		int length = Array.getLength(value);
+		if (length == 0) return;
+		
+		ArrayList<String> arrayList = new ArrayList<String>();
+		
+		for(int i = 0; i < length; i += 1)
+		{
+			String v = Array.get(value, i).toString().trim();
+			if ( v.length() == 0 ) continue;
+			
+			arrayList.add(v);
+		}
+		
+		if ( arrayList.size() == 0 ) return;
+		
+		writer.writeStartElement("array-data");
+		writer.writeAttribute("key", prop);
+
+		for ( String s: arrayList ) {
+			
+			writer.writeStartElement("item");
+			writer.writeCharacters(s);
+			writer.writeEndElement();
+		}
+
+		writer.writeEndElement();
+	}
+
+	// modified by gquercini: if value is null or empty string, the property is not exported.
+	private void writeData(XMLStreamWriter writer, String prop, Object value) throws IOException, XMLStreamException {
+
+		if (value == null) return;
+
+		String valueString = value.toString().trim();
+		if ( valueString.length() == 0 ) return;
+
+		writer.writeStartElement("data");
+		writer.writeAttribute("key", prop);
+		writer.writeCharacters(valueString);
+		writer.writeEndElement();
+	}
+
+	private void writeFooter(XMLStreamWriter writer) throws IOException, XMLStreamException {
+		endElement(writer);
+		endElement(writer);
+		writer.writeEndDocument();
+	}
+
+	private void writeHeader(XMLStreamWriter writer) throws IOException, XMLStreamException {
+		writer.writeStartDocument("UTF-8", "1.0");
+		newLine(writer);
+		writer.writeStartElement("graphml"); // todo properties
+		writer.writeNamespace("xmlns", "http://graphml.graphdrawing.org/xmlns");
+		writer.writeAttribute("xmlns", "http://graphml.graphdrawing.org/xmlns", "xsi", "http://www.w3.org/2001/XMLSchema-instance");
+		writer.writeAttribute("xsi", "", "schemaLocation", "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd");
+		newLine(writer);
+		writer.writeStartElement("graph");
+		writer.writeAttribute("id", "G");
+		writer.writeAttribute("edgedefault", "directed");
+		newLine(writer);
+	}
+
+	private void newLine(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeCharacters("\n");
+	}
+}

--- a/pom.xml~
+++ b/pom.xml~
@@ -26,26 +26,6 @@
     </build>
 
     <repositories>
-	<repository>
-            <id>neo4j-contrib-releases</id>
-            <url>https://raw.github.com/neo4j-contrib/m2/master/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>neo4j-contrib-snapshots</id>
-            <url>https://raw.github.com/neo4j-contrib/m2/master/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
         <repository>
             <id>neo4j</id>
             <url>http://m2.neo4j.org/content/repositories/snapshots/</url>

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@ neo4j-shell-tools adds a bunch of commands to [neo4j-shell](http://docs.neo4j.or
 
 ### What's new
 
-* Added the support for array properties to the (#graphml-import) and (#graphml-export) commands.
-* Modified the (#graphml-export) command so that node/edge properties with empty values are not exported.
+* Added the support for array properties to the [GraphML import](#graphml-import) and [GraphML export](#graphml-export) commands.
+* Modified the [GraphML export](#graphml-export) command so that node/edge properties with empty values are not exported.
 * Modified the POM.xml so that maven correctly finds the geoff jar file.
 
 

--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,9 @@ neo4j-shell-tools adds a bunch of commands to [neo4j-shell](http://docs.neo4j.or
 ### What's new
 
 * Added the support for array properties to the (#graphml-import) and (#graphml-export) commands.
+* Modified the (#graphml-export) command so that node/edge properties with empty values are not exported.
 * Modified the POM.xml so that maven correctly finds the geoff jar file.
 
-Note that empty arrays are not exported.
-Empty arrays can be problematic, as explained [here](http://docs.neo4j.org/chunked/stable/rest-api-property-values.html)
 
 ### Installation
 

--- a/readme.md~
+++ b/readme.md~
@@ -5,10 +5,9 @@ neo4j-shell-tools adds a bunch of commands to [neo4j-shell](http://docs.neo4j.or
 ### What's new
 
 * Added the support for array properties to the (#graphml-import) and (#graphml-export) commands.
+* Modified the (#graphml-export) command so that node/edge properties with empty values are not exported.
 * Modified the POM.xml so that maven correctly finds the geoff jar file.
 
-Note that empty arrays are not exported.
-Empty arrays can be problematic, as explained [here](http://docs.neo4j.org/chunked/stable/rest-api-property-values.html)
 
 ### Installation
 

--- a/readme.md~
+++ b/readme.md~
@@ -239,18 +239,15 @@ An import of [@chrisdiehl](https://twitter.com/chrisdiehl)'s [Enron Dataset](htt
 ### Manual Build & Install
 
 ````
-git clone https://github.com/gquercini/neo4j-shell-tools.git
+git clone git@github.com:jexp/neo4j-shell-tools.git
 cd neo4j-shell-tools
-mvn -DskipTests clean package dependency:copy-dependencies
-
-(tests fails somehow due to the absence of a file import.csv, check the issues in the original project)
-
+mvn clean package dependency:copy-dependencies
 ````
 
 Then copy the jars that get generated into the neo4j lib directory:
 
 ````
-cp target/import-tools-2.0-SNAPSHOT.jar target/dependency/opencsv-2.3.jar target/dependency/geoff-0.5.0.jar target/dependency/mapdb-0.9.3.jar /path/to/neo4j-community-2.0.0/lib
+cp target/import-tools-2.0-SNAPSHOT.jar target/dependency/opencsv-2.3.jar target/dependency/neo4j-geoff-1.7-SNAPSHOT.jar target/dependency/mapdb-0.9.3.jar /path/to/neo4j-community-2.0.0-M05/lib
 ````
 
 or make those two files available on your neo4j-shell classpath

--- a/readme.md~
+++ b/readme.md~
@@ -239,15 +239,18 @@ An import of [@chrisdiehl](https://twitter.com/chrisdiehl)'s [Enron Dataset](htt
 ### Manual Build & Install
 
 ````
-git clone git@github.com:jexp/neo4j-shell-tools.git
+git clone https://github.com/gquercini/neo4j-shell-tools.git
 cd neo4j-shell-tools
-mvn clean package dependency:copy-dependencies
+mvn -DskipTests clean package dependency:copy-dependencies
+
+(tests fails somehow due to the absence of a file import.csv, check the issues in the original project)
+
 ````
 
 Then copy the jars that get generated into the neo4j lib directory:
 
 ````
-cp target/import-tools-2.0-SNAPSHOT.jar target/dependency/opencsv-2.3.jar target/dependency/neo4j-geoff-1.7-SNAPSHOT.jar target/dependency/mapdb-0.9.3.jar /path/to/neo4j-community-2.0.0-M05/lib
+cp target/import-tools-2.0-SNAPSHOT.jar target/dependency/opencsv-2.3.jar target/dependency/geoff-0.5.0.jar target/dependency/mapdb-0.9.3.jar /path/to/neo4j-community-2.0.0/lib
 ````
 
 or make those two files available on your neo4j-shell classpath

--- a/src/main/java/org/neo4j/shell/tools/imp/ExportGraphMLApp.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/ExportGraphMLApp.java
@@ -26,60 +26,60 @@ import java.io.FileWriter;
  */
 public class ExportGraphMLApp extends AbstractApp {
 
-    {
-        addOptionDefinition( "o", new OptionDefinition( OptionValueType.MUST,
-                "Output GraphML file" ) );
-        addOptionDefinition( "t", new OptionDefinition( OptionValueType.MAY,
-                "Write key types upfront (double pass)" ) );
-        addOptionDefinition( "r", new OptionDefinition( OptionValueType.MAY,
-                "Add all nodes of selected relationships" ) );
-    }
+	{
+		addOptionDefinition( "o", new OptionDefinition( OptionValueType.MUST,
+				"Output GraphML file" ) );
+		addOptionDefinition( "t", new OptionDefinition( OptionValueType.MAY,
+				"Write key types upfront (double pass)" ) );
+		addOptionDefinition( "r", new OptionDefinition( OptionValueType.MAY,
+				"Add all nodes of selected relationships" ) );
+	}
 
-    private ExecutionEngine engine;
-    protected ExecutionEngine getEngine() {
-        if (engine==null) engine=new ExecutionEngine(getServer().getDb(), StringLogger.SYSTEM);
-        return engine;
-    }
+	private ExecutionEngine engine;
+	protected ExecutionEngine getEngine() {
+		if (engine==null) engine=new ExecutionEngine(getServer().getDb(), StringLogger.SYSTEM);
+		return engine;
+	}
 
-    @Override
-    public String getName() {
-        return "export-graphml";
-    }
-
-
-    @Override
-    public GraphDatabaseShellServer getServer() {
-        return (GraphDatabaseShellServer) super.getServer();
-    }
-
-    private SubGraph cypherResultSubGraph(String query, boolean relsBetween) {
-        try (Transaction tx = getServer().getDb().beginTx()) {
-            ExecutionResult result = getEngine().execute(query);
-            SubGraph subGraph = CypherResultSubGraph.from(result, getServer().getDb(), relsBetween);
-            tx.success();
-            return subGraph;
-        }
-    }
+	@Override
+	public String getName() {
+		return "export-graphml";
+	}
 
 
-    @Override
-    public Continuation execute(AppCommandParser parser, Session session, Output out) throws Exception {
-        Config config = Config.fromOptions(parser);
+	@Override
+	public GraphDatabaseShellServer getServer() {
+		return (GraphDatabaseShellServer) super.getServer();
+	}
 
-        String fileName = parser.option("o", null);
-        boolean relsBetween = parser.options().containsKey("r");
-        BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
+	private SubGraph cypherResultSubGraph(String query, boolean relsBetween) {
+		try (Transaction tx = getServer().getDb().beginTx()) {
+			ExecutionResult result = getEngine().execute(query);
+			SubGraph subGraph = CypherResultSubGraph.from(result, getServer().getDb(), relsBetween);
+			tx.success();
+			return subGraph;
+		}
+	}
 
-        ProgressReporter reporter = new ProgressReporter(null, out);
 
-        GraphDatabaseService db = getServer().getDb();
+	@Override
+	public Continuation execute(AppCommandParser parser, Session session, Output out) throws Exception {
+		Config config = Config.fromOptions(parser);
 
-        Format exportFormat = new XmlGraphMLFormat(db);
-        String query = Config.extractQuery(parser);
-        SubGraph graph = query.isEmpty() ? new DatabaseSubGraph(db) : cypherResultSubGraph(query,relsBetween);
-        exportFormat.dump(graph, writer, reporter, config);
-        writer.close();
-        reporter.progress("Wrote to GraphML-file " + fileName);
-        return Continuation.INPUT_COMPLETE;
-    }
+		String fileName = parser.option("o", null);
+		boolean relsBetween = parser.options().containsKey("r");
+		BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
+
+		ProgressReporter reporter = new ProgressReporter(null, out);
+
+		GraphDatabaseService db = getServer().getDb();
+
+		Format exportFormat = new XmlGraphMLFormat(db);
+		String query = Config.extractQuery(parser);
+		SubGraph graph = query.isEmpty() ? new DatabaseSubGraph(db) : cypherResultSubGraph(query,relsBetween);
+		exportFormat.dump(graph, writer, reporter, config);
+		writer.close();
+		reporter.progress("Wrote to GraphML-file " + fileName);
+		return Continuation.INPUT_COMPLETE;
+	}
 }

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
@@ -10,9 +10,12 @@ import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,236 +24,316 @@ import java.util.Map;
  */
 public class XmlGraphMLReader {
 
-    public static final String LABEL_SPLIT = " *: *";
-    private GraphDatabaseService gdb;
-    private boolean storeNodeIds;
-    private DynamicRelationshipType defaultRelType =DynamicRelationshipType.withName("UNKNOWN");
-    private int batchSize = 40000;
-    private Reporter reporter;
-    private boolean labels;
+	public static final String LABEL_SPLIT = " *: *";
+	private GraphDatabaseService gdb;
+	private boolean storeNodeIds;
+	private DynamicRelationshipType defaultRelType =DynamicRelationshipType.withName("UNKNOWN");
+	private int batchSize = 40000;
+	private Reporter reporter;
+	private boolean labels;
 
-    public XmlGraphMLReader storeNodeIds() {
-        this.storeNodeIds = true;
-        return this;
-    }
+	public XmlGraphMLReader storeNodeIds() {
+		this.storeNodeIds = true;
+		return this;
+	}
 
-    public XmlGraphMLReader relType(String name) {
-        this.defaultRelType = DynamicRelationshipType.withName(name);
-        return this;
-    }
+	public XmlGraphMLReader relType(String name) {
+		this.defaultRelType = DynamicRelationshipType.withName(name);
+		return this;
+	}
 
-    public XmlGraphMLReader batchSize(int batchSize) {
-        this.batchSize = batchSize;
-        return this;
-    }
+	public XmlGraphMLReader batchSize(int batchSize) {
+		this.batchSize = batchSize;
+		return this;
+	}
 
-    public XmlGraphMLReader nodeLabels(boolean readLabels) {
-        this.labels = readLabels;
-        return this;
-    }
+	public XmlGraphMLReader nodeLabels(boolean readLabels) {
+		this.labels = readLabels;
+		return this;
+	}
 
-    public XmlGraphMLReader reporter(Reporter reporter) {
-        this.reporter = reporter;
-        return this;
-    }
+	public XmlGraphMLReader reporter(Reporter reporter) {
+		this.reporter = reporter;
+		return this;
+	}
 
+	// modified by gquercini to add array support
+	enum Type {
+		BOOLEAN() {
+			Object parse(Object value) {
+				return Boolean.valueOf((String)value);
+			}
+		}, A_BOOLEAN() {
+			Object parse(Object value) {
+				Boolean[] arrayValue = new Boolean[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
+			}
+		}, INT() {
+			Object parse(Object value) {
+				return Integer.parseInt((String)value);
+			}
+		}, A_INT() {
+			Object parse(Object value) {
+				Integer[] arrayValue = new Integer[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
-    enum Type {
-        BOOLEAN() {
-            Object parse(String value) {
-                return Boolean.valueOf(value);
-            }
-        }, INT() {
-            Object parse(String value) {
-                return Integer.parseInt(value);
-            }
-        }, LONG() {
-            Object parse(String value) {
-                return Long.parseLong(value);
-            }
-        }, FLOAT() {
-            Object parse(String value) {
-                return Float.parseFloat(value);
-            }
-        }, DOUBLE() {
-            Object parse(String value) {
-                return Double.parseDouble(value);
-            }
+			}
+		}, LONG() {
+			Object parse(Object value) {
+				return Long.parseLong((String)value);
+			}
+		}, A_LONG() {
+			Object parse(Object value) {
+				Long[] arrayValue = new Long[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
-        }, STRING() {
-            Object parse(String value) {
-                return value;
-            }
-        };
+			}
+		},FLOAT() {
+			Object parse(Object value) {
+				return Float.parseFloat((String)value);
+			}
+		}, A_FLOAT() {
+			Object parse(Object value) {
+				Float[] arrayValue = new Float[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
-        abstract Object parse(String value);
+			}
+		}, DOUBLE() {
+			Object parse(Object value) {
+				return Double.parseDouble((String)value);
+			}
 
-        public static Type forType(String type) {
-            return valueOf(type.trim().toUpperCase());
-        }
-    }
+		}, A_DOUBLE() {
+			Object parse(Object value) {
+				Double[] arrayValue = new Double[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
-    static class Key {
-        String id;
-        String name;
-        boolean forNode;
-        Type type;
-        Object defaultValue;
+			}
+		}, STRING() {
+			Object parse(Object value) {
+				return value;
+			}
+		}, A_STRING() {
+			Object parse(Object value) {
+				String[] arrayValue = new String[((ArrayList<Object>)value).size()];
+				return ((ArrayList<Object>)value).toArray(arrayValue);
 
-        public Key(String id, String name, String type, String forNode) {
-            this.id = id;
-            this.name = name;
-            this.type = Type.forType(type);
-            this.forNode = forNode == null || forNode.equalsIgnoreCase("node");
-        }
+			}
+		};
 
-        private static Key defaultKey(String id, boolean forNode) {
-            return new Key(id,id,"string", forNode ? "node" : "edge");
-        }
+		abstract Object parse(Object value);
 
-        public void setDefault(String data) {
-            this.defaultValue = type.parse(data);
-        }
+		public static Type forType(String type) {
 
-        public Object parseValue(String input) {
-            if (input == null || input.trim().isEmpty()) return defaultValue;
-            return type.parse(input);
-        }
-    }
+			return valueOf(type.trim().toUpperCase());
+		}
+	}
 
-    public static final QName ID = QName.valueOf("id");
-    public static final QName LABELS = QName.valueOf("labels");
-    public static final QName SOURCE = QName.valueOf("source");
-    public static final QName TARGET = QName.valueOf("target");
-    public static final QName LABEL = QName.valueOf("label");
-    public static final QName FOR = QName.valueOf("for");
-    public static final QName NAME = QName.valueOf("attr.name");
-    public static final QName TYPE = QName.valueOf("attr.type");
-    public static final QName KEY = QName.valueOf("key");
+	static class Key {
+		String id;
+		String name;
+		boolean forNode;
+		Type type;
+		Object defaultValue;
 
-    public XmlGraphMLReader(GraphDatabaseService gdb) {
-        this.gdb = gdb;
-    }
+		public Key(String id, String name, String type, String forNode) {
+			this.id = id;
+			this.name = name;
+			this.type = Type.forType(type);
+			this.forNode = forNode == null || forNode.equalsIgnoreCase("node");
+		}
 
-    public long parseXML(Reader input, NodeCache cache) throws XMLStreamException {
-        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-        inputFactory.setProperty("javax.xml.stream.isCoalescing", true);
-        XMLEventReader reader = inputFactory.createXMLEventReader(input);
-        PropertyContainer last = null;
-        Map<String, Key> nodeKeys = new HashMap<>();
-        Map<String, Key> relKeys = new HashMap<>();
-        int count = 0;
-        try (BatchTransaction tx = new BatchTransaction(gdb, batchSize * 10, reporter)) {
+		private static Key defaultKey(String id, boolean forNode) {
+			return new Key(id,id,"string", forNode ? "node" : "edge");
+		}
 
-            while (reader.hasNext()) {
-                XMLEvent event = (XMLEvent) reader.next();
-                if (event.isStartElement()) {
+		public void setDefault(String data) {
+			this.defaultValue = type.parse(data);
+		}
 
-                    StartElement element = event.asStartElement();
-                    String name = element.getName().getLocalPart();
+		public Object parseValue(String input) {
+			if (input == null || input.trim().isEmpty()) return defaultValue;
+			return type.parse(input);
+		}
+		
+		public Object parseValue(ArrayList<Object> input) {
+			if (input == null || input.size() == 0) return defaultValue;
+			return type.parse(input);
+		}
+	}
 
-                    if (name.equals("graphml") || name.equals("graph")) continue;
-                    if (name.equals("key")) {
-                        String id = getAttribute(element, ID);
-                        Key key = new Key(id, getAttribute(element, NAME), getAttribute(element, TYPE), getAttribute(element, FOR));
+	public static final QName ID = QName.valueOf("id");
+	public static final QName LABELS = QName.valueOf("labels");
+	public static final QName SOURCE = QName.valueOf("source");
+	public static final QName TARGET = QName.valueOf("target");
+	public static final QName LABEL = QName.valueOf("label");
+	public static final QName FOR = QName.valueOf("for");
+	public static final QName NAME = QName.valueOf("attr.name");
+	public static final QName TYPE = QName.valueOf("attr.type");
+	public static final QName KEY = QName.valueOf("key");
 
-                        XMLEvent next = peek(reader);
-                        if (next.isStartElement() && next.asStartElement().getName().getLocalPart().equals("default")) {
-                            reader.nextEvent().asStartElement();
-                            key.setDefault(reader.nextEvent().asCharacters().getData());
-                        }
-                        if (key.forNode) nodeKeys.put(id, key);
-                        else relKeys.put(id, key);
-                        continue;
-                    }
-                    if (name.equals("data")) {
-                        if (last == null) continue;
-                        String id = getAttribute(element, KEY);
-                        boolean isNode = last instanceof Node;
-                        Key key = isNode ? nodeKeys.get(id) : relKeys.get(id);
-                        if (key == null) key = Key.defaultKey(id, isNode);
-                        Object value = key.defaultValue;
-                        XMLEvent next = peek(reader);
-                        if (next.isCharacters()) {
-                            value = key.parseValue(reader.nextEvent().asCharacters().getData());
-                        }
-                        if (value != null) {
-                            if (this.labels && isNode && id.equals("labels")) {
-                                addLabels((Node)last,value.toString());
-                            } else if (!this.labels || isNode || !id.equals("label")) {
-                                last.setProperty(key.name, value);
-                                if (reporter != null) reporter.update(0, 0, 1);
-                            }
-                        }
-                        continue;
-                    }
-                    if (name.equals("node")) {
-                        tx.increment();
-                        String id = getAttribute(element, ID);
-                        Node node = gdb.createNode();
-                        if (this.labels) {
-                            String labels = getAttribute(element, LABELS);
-                            addLabels(node, labels);
-                        }
-                        if (storeNodeIds) node.setProperty("id", id);
-                        setDefaults(nodeKeys, node);
-                        last = node;
-                        cache.put(id, node.getId());
-                        if (reporter != null) reporter.update(1, 0, 0);
-                        count++;
-                        continue;
-                    }
-                    if (name.equals("edge")) {
-                        tx.increment();
-                        String source = getAttribute(element, SOURCE);
-                        String target = getAttribute(element, TARGET);
-                        String label = getAttribute(element, LABEL);
-                        Node from = gdb.getNodeById(cache.get(source));
-                        Node to = gdb.getNodeById(cache.get(target));
-                        RelationshipType type = label != null ? DynamicRelationshipType.withName(label) : defaultRelType;
-                        Relationship relationship = from.createRelationshipTo(to, type);
-                        setDefaults(relKeys, relationship);
-                        if (reporter != null) reporter.update(0, 1, 0);
-                        count++;
-                        last = relationship;
-                        continue;
-                    }
-                }
-            }
-        }
-        return count;
-    }
+	public XmlGraphMLReader(GraphDatabaseService gdb) {
+		this.gdb = gdb;
+	}
 
-    private void addLabels(Node node, String labels) {
-        if (labels==null) return;
-        labels = labels.trim();
-        if (labels.isEmpty()) return;
-        String[] parts = labels.split(LABEL_SPLIT);
-        for (String part : parts) {
-            if (part.trim().isEmpty()) continue;
-            node.addLabel(DynamicLabel.label(part.trim()));
-        }
-    }
+	public long parseXML(Reader input, NodeCache cache) throws XMLStreamException {
+		XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+		inputFactory.setProperty("javax.xml.stream.isCoalescing", true);
+		XMLEventReader reader = inputFactory.createXMLEventReader(input);
+		PropertyContainer last = null;
+		ArrayList<Object> array = null;
+		Key arrayKey = null;
+		Type arrayComponentType = null;
+		Map<String, Key> nodeKeys = new HashMap<>();
+		Map<String, Key> relKeys = new HashMap<>();
+		int count = 0;
+		try (BatchTransaction tx = new BatchTransaction(gdb, batchSize * 10, reporter)) {
 
-    private XMLEvent peek(XMLEventReader reader) throws XMLStreamException {
-        XMLEvent peek = reader.peek();
-        if (peek.isCharacters() && (peek.asCharacters().isWhiteSpace())) {
-            reader.nextEvent();
-            return peek(reader);
-        }
-        return peek;
-    }
+			while (reader.hasNext()) {
+				XMLEvent event = (XMLEvent) reader.next();
+				if (event.isStartElement()) {
 
-    private void setDefaults(Map<String, Key> keys, PropertyContainer pc) {
-        if (keys.isEmpty()) return;
-        for (Key key : keys.values()) {
-            if (key.defaultValue!=null) pc.setProperty(key.name,key.defaultValue);
-        }
-    }
+					StartElement element = event.asStartElement();
+					String name = element.getName().getLocalPart();
 
-    private String getAttribute(StartElement element, QName qname) {
-        Attribute attribute = element.getAttributeByName(qname);
-        return attribute != null ? attribute.getValue() : null;
-    }
+					if (name.equals("graphml") || name.equals("graph")) continue;
+					if (name.equals("key")) {
+						String id = getAttribute(element, ID);
+						Key key = new Key(id, getAttribute(element, NAME), getAttribute(element, TYPE), getAttribute(element, FOR));
+
+						XMLEvent next = peek(reader);
+						if (next.isStartElement() && next.asStartElement().getName().getLocalPart().equals("default")) {
+							reader.nextEvent().asStartElement();
+							key.setDefault(reader.nextEvent().asCharacters().getData());
+						}
+						if (key.forNode) nodeKeys.put(id, key);
+						else relKeys.put(id, key);
+						continue;
+					}
+					if (name.equals("data")) {
+						if (last == null) continue;
+						String id = getAttribute(element, KEY);
+						boolean isNode = last instanceof Node;
+						Key key = isNode ? nodeKeys.get(id) : relKeys.get(id);
+						if (key == null) key = Key.defaultKey(id, isNode);
+						Object value = key.defaultValue;
+						XMLEvent next = peek(reader);
+						if (next.isCharacters()) {
+							value = key.parseValue(reader.nextEvent().asCharacters().getData());
+						}
+						if (value != null) {
+							if (this.labels && isNode && id.equals("labels")) {
+								addLabels((Node)last,value.toString());
+							} else if (!this.labels || isNode || !id.equals("label")) {
+								last.setProperty(key.name, value);
+								if (reporter != null) reporter.update(0, 0, 1);
+							}
+						}
+						continue;
+					}
+					// added by gquercini to add array support.
+					if( name.equals("array-data") ) {
+						if( last == null ) continue;
+						
+						String id = getAttribute(element, KEY);
+						boolean isNode = last instanceof Node;
+						Key key = isNode ? nodeKeys.get(id) : relKeys.get(id);
+						if (key == null) key = Key.defaultKey(id, isNode);
+						array = new ArrayList<Object>();
+						arrayKey = key;
+						arrayComponentType = Type.forType(arrayKey.type.name().substring(2));
+						
+					}
+					// added by gquercini to add array support.
+					if( name.equals("item") ) {
+						if( array == null ) continue;
+						XMLEvent next = peek(reader);
+						if (next.isCharacters()) 
+						{
+							Object value = arrayComponentType.parse(reader.nextEvent().asCharacters().getData());
+							array.add(value);
+						}
+						
+					}
+					if (name.equals("node")) {
+						tx.increment();
+						String id = getAttribute(element, ID);
+						Node node = gdb.createNode();
+						if (this.labels) {
+							String labels = getAttribute(element, LABELS);
+							addLabels(node, labels);
+						}
+						if (storeNodeIds) node.setProperty("id", id);
+						setDefaults(nodeKeys, node);
+						last = node;
+						cache.put(id, node.getId());
+						if (reporter != null) reporter.update(1, 0, 0);
+						count++;
+						continue;
+					}
+					if (name.equals("edge")) {
+						tx.increment();
+						String source = getAttribute(element, SOURCE);
+						String target = getAttribute(element, TARGET);
+						String label = getAttribute(element, LABEL);
+						Node from = gdb.getNodeById(cache.get(source));
+						Node to = gdb.getNodeById(cache.get(target));
+						RelationshipType type = label != null ? DynamicRelationshipType.withName(label) : defaultRelType;
+						Relationship relationship = from.createRelationshipTo(to, type);
+						setDefaults(relKeys, relationship);
+						if (reporter != null) reporter.update(0, 1, 0);
+						count++;
+						last = relationship;
+						continue;
+					}
+				}
+				else
+					if ( event.isEndElement() ) {
+						EndElement element = event.asEndElement();
+						String name = element.getName().getLocalPart();
+						if( name.equals("array-data") ) {
+							last.setProperty(arrayKey.name, arrayKey.parseValue(array));
+							if (reporter != null) reporter.update(0, 0, 1);
+							array = null;
+							arrayKey = null;
+							arrayComponentType = null;
+						}
+					}
+			}
+		}
+		return count;
+	}
+
+	private void addLabels(Node node, String labels) {
+		if (labels==null) return;
+		labels = labels.trim();
+		if (labels.isEmpty()) return;
+		String[] parts = labels.split(LABEL_SPLIT);
+		for (String part : parts) {
+			if (part.trim().isEmpty()) continue;
+			node.addLabel(DynamicLabel.label(part.trim()));
+		}
+	}
+
+	private XMLEvent peek(XMLEventReader reader) throws XMLStreamException {
+		XMLEvent peek = reader.peek();
+		if (peek.isCharacters() && (peek.asCharacters().isWhiteSpace())) {
+			reader.nextEvent();
+			return peek(reader);
+		}
+		return peek;
+	}
+
+	private void setDefaults(Map<String, Key> keys, PropertyContainer pc) {
+		if (keys.isEmpty()) return;
+		for (Key key : keys.values()) {
+			if (key.defaultValue!=null) pc.setProperty(key.name,key.defaultValue);
+		}
+	}
+
+	private String getAttribute(StartElement element, QName qname) {
+		Attribute attribute = element.getAttributeByName(qname);
+		return attribute != null ? attribute.getValue() : null;
+	}
 }

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
@@ -9,11 +9,12 @@ import org.neo4j.shell.tools.imp.util.Reporter;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+
 import java.io.IOException;
 import java.io.Writer;
+import java.lang.reflect.Array;
 import java.util.*;
 
-import static org.neo4j.helpers.collection.Iterables.join;
 import static org.neo4j.shell.tools.imp.util.MetaInformation.getLabelsString;
 
 /**
@@ -22,145 +23,195 @@ import static org.neo4j.shell.tools.imp.util.MetaInformation.getLabelsString;
  */
 public class XmlGraphMLWriter {
 
-    public void write(SubGraph graph, Writer writer, Reporter reporter, Config config) throws IOException, XMLStreamException {
-        XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
-        XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);
-        writeHeader(xmlWriter);
-        if (config.useTypes()) writeKeyTypes(xmlWriter, graph);
-        for (Node node : graph.getNodes()) {
-            int props = writeNode(xmlWriter, node);
-            reporter.update(1, 0, props);
-        }
-        for (Relationship rel : graph.getRelationships()) {
-            int props = writeRelationship(xmlWriter, rel);
-            reporter.update(0, 1, props);
-        }
-        writeFooter(xmlWriter);
-    }
+	public void write(SubGraph graph, Writer writer, Reporter reporter, Config config) throws IOException, XMLStreamException {
+		XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
+		XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);
+		writeHeader(xmlWriter);
+		if (config.useTypes()) writeKeyTypes(xmlWriter, graph);
+		for (Node node : graph.getNodes()) {
+			int props = writeNode(xmlWriter, node);
+			reporter.update(1, 0, props);
+		}
+		for (Relationship rel : graph.getRelationships()) {
+			int props = writeRelationship(xmlWriter, rel);
+			reporter.update(0, 1, props);
+		}
+		writeFooter(xmlWriter);
+	}
 
-    private void writeKeyTypes(XMLStreamWriter writer, SubGraph ops) throws IOException, XMLStreamException {
-        Map<String, Class> keyTypes = new HashMap<>();
-        for (Node node : ops.getNodes()) {
-            updateKeyTypes(keyTypes, node);
-        }
-        writeKeyTypes(writer, keyTypes, "node");
-        keyTypes.clear();
-        for (Relationship rel : ops.getRelationships()) {
-            updateKeyTypes(keyTypes, rel);
-        }
-        writeKeyTypes(writer, keyTypes, "edge");
-    }
+	private void writeKeyTypes(XMLStreamWriter writer, SubGraph ops) throws IOException, XMLStreamException {
+		Map<String, Class> keyTypes = new HashMap<>();
+		for (Node node : ops.getNodes()) {
+			updateKeyTypes(keyTypes, node);
+		}
+		writeKeyTypes(writer, keyTypes, "node");
+		keyTypes.clear();
+		for (Relationship rel : ops.getRelationships()) {
+			updateKeyTypes(keyTypes, rel);
+		}
+		writeKeyTypes(writer, keyTypes, "edge");
+	}
 
-    private void writeKeyTypes(XMLStreamWriter writer, Map<String, Class> keyTypes, String forType) throws IOException, XMLStreamException {
-        for (Map.Entry<String, Class> entry : keyTypes.entrySet()) {
-            String type = MetaInformation.typeFor(entry.getValue(), MetaInformation.GRAPHML_ALLOWED);
-            if (type == null) continue;
-            writer.writeEmptyElement("key");
-            writer.writeAttribute("id", entry.getKey());
-            writer.writeAttribute("for", forType);
-            writer.writeAttribute("attr.name", entry.getKey());
-            writer.writeAttribute("attr.type", type);
-            newLine(writer);
-        }
-    }
+	private void writeKeyTypes(XMLStreamWriter writer, Map<String, Class> keyTypes, String forType) throws IOException, XMLStreamException {
+		for (Map.Entry<String, Class> entry : keyTypes.entrySet()) {
 
-    private void updateKeyTypes(Map<String, Class> keyTypes, PropertyContainer pc) {
-        for (String prop : pc.getPropertyKeys()) {
-            Object value = pc.getProperty(prop);
-            Class storedClass = keyTypes.get(prop);
-            if (storedClass == null) {
-                keyTypes.put(prop, value.getClass());
-                continue;
-            }
-            if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
-            keyTypes.put(prop, void.class);
-        }
-    }
+			String type = MetaInformation.typeFor(entry.getValue(), MetaInformation.GRAPHML_ALLOWED);
 
-    private int writeNode(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
-        writer.writeStartElement("node");
-        writer.writeAttribute("id", id(node));
-        writeLabels(writer, node);
-        writeLabelsAsData(writer, node);
-        int props = writeProps(writer, node);
-        endElement(writer);
-        return props;
-    }
+			if (type == null) continue;
+			writer.writeEmptyElement("key");
+			writer.writeAttribute("id", entry.getKey());
+			writer.writeAttribute("for", forType);
+			writer.writeAttribute("attr.name", entry.getKey());
+			writer.writeAttribute("attr.type", type);
+			newLine(writer);
+		}
+	}
 
-    private String id(Node node) {
-        return "n" + node.getId();
-    }
+	private void updateKeyTypes(Map<String, Class> keyTypes, PropertyContainer pc) {
+		for (String prop : pc.getPropertyKeys()) {
+			Object value = pc.getProperty(prop);
+			Class storedClass = keyTypes.get(prop);
 
-    private void writeLabels(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
-        String labelsString = getLabelsString(node);
-        if (!labelsString.isEmpty()) writer.writeAttribute("labels", labelsString);
-    }
+			if (storedClass == null) {
+				keyTypes.put(prop, value.getClass());
 
-    private void writeLabelsAsData(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
-        String labelsString = getLabelsString(node);
-        if (labelsString.isEmpty()) return;
-        writeData(writer, "labels", labelsString);
-    }
+				continue;
+			}
+			if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
+			keyTypes.put(prop, void.class);
+		}
+	}
 
-    private int writeRelationship(XMLStreamWriter writer, Relationship rel) throws IOException, XMLStreamException {
-        writer.writeStartElement("edge");
-        writer.writeAttribute("id", id(rel));
-        writer.writeAttribute("source", id(rel.getStartNode()));
-        writer.writeAttribute("target", id(rel.getEndNode()));
-        writer.writeAttribute("label", rel.getType().name());
-        writeData(writer, "label", rel.getType().name());
-        int props = writeProps(writer, rel);
-        endElement(writer);
-        return props;
-    }
+	private int writeNode(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		writer.writeStartElement("node");
+		writer.writeAttribute("id", id(node));
+		writeLabels(writer, node);
+		writeLabelsAsData(writer, node);
+		int props = writeProps(writer, node);
+		endElement(writer);
+		return props;
+	}
 
-    private String id(Relationship rel) {
-        return "e" + rel.getId();
-    }
+	private String id(Node node) {
+		return "n" + node.getId();
+	}
 
-    private void endElement(XMLStreamWriter writer) throws XMLStreamException {
-        writer.writeEndElement();
-        newLine(writer);
-    }
+	private void writeLabels(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		String labelsString = getLabelsString(node);
+		if (!labelsString.isEmpty()) writer.writeAttribute("labels", labelsString);
+	}
 
-    private int writeProps(XMLStreamWriter writer, PropertyContainer node) throws IOException, XMLStreamException {
-        int count = 0;
-        for (String prop : node.getPropertyKeys()) {
-            Object value = node.getProperty(prop);
-            writeData(writer, prop, value);
-            count++;
-        }
-        return count;
-    }
+	private void writeLabelsAsData(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+		String labelsString = getLabelsString(node);
+		if (labelsString.isEmpty()) return;
+		writeData(writer, "labels", labelsString);
+	}
 
-    private void writeData(XMLStreamWriter writer, String prop, Object value) throws IOException, XMLStreamException {
-        writer.writeStartElement("data");
-        writer.writeAttribute("key", prop);
-        if (value != null) writer.writeCharacters(value.toString());
-        writer.writeEndElement();
-    }
+	private int writeRelationship(XMLStreamWriter writer, Relationship rel) throws IOException, XMLStreamException {
+		writer.writeStartElement("edge");
+		writer.writeAttribute("id", id(rel));
+		writer.writeAttribute("source", id(rel.getStartNode()));
+		writer.writeAttribute("target", id(rel.getEndNode()));
+		writer.writeAttribute("label", rel.getType().name());
+		writeData(writer, "label", rel.getType().name());
+		int props = writeProps(writer, rel);
+		endElement(writer);
+		return props;
+	}
 
-    private void writeFooter(XMLStreamWriter writer) throws IOException, XMLStreamException {
-        endElement(writer);
-        endElement(writer);
-        writer.writeEndDocument();
-    }
+	private String id(Relationship rel) {
+		return "e" + rel.getId();
+	}
 
-    private void writeHeader(XMLStreamWriter writer) throws IOException, XMLStreamException {
-        writer.writeStartDocument("UTF-8", "1.0");
-        newLine(writer);
-        writer.writeStartElement("graphml"); // todo properties
-        writer.writeNamespace("xmlns", "http://graphml.graphdrawing.org/xmlns");
-        writer.writeAttribute("xmlns", "http://graphml.graphdrawing.org/xmlns", "xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        writer.writeAttribute("xsi", "", "schemaLocation", "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd");
-        newLine(writer);
-        writer.writeStartElement("graph");
-        writer.writeAttribute("id", "G");
-        writer.writeAttribute("edgedefault", "directed");
-        newLine(writer);
-    }
+	private void endElement(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeEndElement();
+		newLine(writer);
+	}
 
-    private void newLine(XMLStreamWriter writer) throws XMLStreamException {
-        writer.writeCharacters("\n");
-    }
+	// modified by gquercini to add array support
+	private int writeProps(XMLStreamWriter writer, PropertyContainer node) throws IOException, XMLStreamException {
+		int count = 0;
+		for (String prop : node.getPropertyKeys()) {
+			Object value = node.getProperty(prop);
+			Class valueClass = value.getClass();
+
+			if (valueClass.isArray()) 
+				writeArrayData(writer, prop, value); // added by gquercini to add array support
+			else
+				writeData(writer, prop, value);
+			count++;
+		}
+		return count;
+	}
+
+	// added by gquercini to add array support
+	private void writeArrayData(XMLStreamWriter writer, String prop, Object value) throws IOException, XMLStreamException {
+
+		if ( value == null ) return;
+
+		int length = Array.getLength(value);
+		if (length == 0) return;
+		
+		ArrayList<String> arrayList = new ArrayList<String>();
+		
+		for(int i = 0; i < length; i += 1)
+		{
+			String v = Array.get(value, i).toString().trim();
+			if ( v.length() == 0 ) continue;
+			
+			arrayList.add(v);
+		}
+		
+		if ( arrayList.size() == 0 ) return;
+		
+		writer.writeStartElement("array-data");
+		writer.writeAttribute("key", prop);
+
+		for ( String s: arrayList ) {
+			
+			writer.writeStartElement("item");
+			writer.writeCharacters(s);
+			writer.writeEndElement();
+		}
+
+		writer.writeEndElement();
+	}
+
+	// modified by gquercini: if value is null or empty string, the property is not exported.
+	private void writeData(XMLStreamWriter writer, String prop, Object value) throws IOException, XMLStreamException {
+
+		if (value == null) return;
+
+		String valueString = value.toString().trim();
+		if ( valueString.length() == 0 ) return;
+
+		writer.writeStartElement("data");
+		writer.writeAttribute("key", prop);
+		writer.writeCharacters(valueString);
+		writer.writeEndElement();
+	}
+
+	private void writeFooter(XMLStreamWriter writer) throws IOException, XMLStreamException {
+		endElement(writer);
+		endElement(writer);
+		writer.writeEndDocument();
+	}
+
+	private void writeHeader(XMLStreamWriter writer) throws IOException, XMLStreamException {
+		writer.writeStartDocument("UTF-8", "1.0");
+		newLine(writer);
+		writer.writeStartElement("graphml"); // todo properties
+		writer.writeNamespace("xmlns", "http://graphml.graphdrawing.org/xmlns");
+		writer.writeAttribute("xmlns", "http://graphml.graphdrawing.org/xmlns", "xsi", "http://www.w3.org/2001/XMLSchema-instance");
+		writer.writeAttribute("xsi", "", "schemaLocation", "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd");
+		newLine(writer);
+		writer.writeStartElement("graph");
+		writer.writeAttribute("id", "G");
+		writer.writeAttribute("edgedefault", "directed");
+		newLine(writer);
+	}
+
+	private void newLine(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeCharacters("\n");
+	}
 }

--- a/src/main/java/org/neo4j/shell/tools/imp/util/MetaInformation.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/MetaInformation.java
@@ -17,51 +17,62 @@ import static org.neo4j.helpers.collection.Iterables.join;
  */
 public class MetaInformation {
 
-    public static Map<String,Class> collectPropTypesForNodes(SubGraph graph) {
-        Map<String,Class> propTypes = new LinkedHashMap<>();
-        for (Node node : graph.getNodes()) {
-            updateKeyTypes(propTypes, node);
-        }
-        return propTypes;
-    }
-    public static Map<String,Class> collectPropTypesForRelationships(SubGraph graph) {
-        Map<String,Class> propTypes = new LinkedHashMap<>();
-        for (Relationship node : graph.getRelationships()) {
-            updateKeyTypes(propTypes, node);
-        }
-        return propTypes;
-    }
+	public static Map<String,Class> collectPropTypesForNodes(SubGraph graph) {
+		Map<String,Class> propTypes = new LinkedHashMap<>();
+		for (Node node : graph.getNodes()) {
+			updateKeyTypes(propTypes, node);
+		}
+		return propTypes;
+	}
+	public static Map<String,Class> collectPropTypesForRelationships(SubGraph graph) {
+		Map<String,Class> propTypes = new LinkedHashMap<>();
+		for (Relationship node : graph.getRelationships()) {
+			updateKeyTypes(propTypes, node);
+		}
+		return propTypes;
+	}
 
-    private static void updateKeyTypes(Map<String, Class> keyTypes, PropertyContainer pc) {
-        for (String prop : pc.getPropertyKeys()) {
-            Object value = pc.getProperty(prop);
-            Class storedClass = keyTypes.get(prop);
-            if (storedClass==null) {
-                keyTypes.put(prop,value.getClass());
-                continue;
-            }
-            if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
-            keyTypes.put(prop, void.class);
-        }
-    }
+	private static void updateKeyTypes(Map<String, Class> keyTypes, PropertyContainer pc) {
+		for (String prop : pc.getPropertyKeys()) {
+			Object value = pc.getProperty(prop);
+			Class storedClass = keyTypes.get(prop);
+			if (storedClass==null) {
+				keyTypes.put(prop,value.getClass());
+				continue;
+			}
+			if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
+			keyTypes.put(prop, void.class);
+		}
+	}
 
-    public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));
+	public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));
 
-    public static String typeFor(Class value, Set<String> allowed) {
-        if (value == void.class) return null;
-        if (value.isArray()) return null; // TODO arrays
-        String name = value.getSimpleName().toLowerCase();
-        if (name.equals("integer")) name="int";
-        if (allowed==null || allowed.contains(name)) return name;
-        if (Number.class.isAssignableFrom(value)) return "int";
-        return null;
-    }
+	// modified by gquercini to add array support
+	public static String typeFor(Class value, Set<String> allowed) {
+		if (value == void.class) return null;
+		
+		// modified by gquercini to add array support
+		String name;
+		if (value.isArray())  
+			name = value.getComponentType().getSimpleName().toLowerCase(); 
+		else
+			name = value.getSimpleName().toLowerCase();
+		
+		if (name.equals("integer")) name="int";
+		
+		if (allowed==null || allowed.contains(name)) return value.isArray() ? "a_" + name : name;
+		if (Number.class.isAssignableFrom(value)) return value.isArray() ? "a_int" : "int";
+		
+		
+		
+		return null;
+	}
 
-    public static String getLabelsString(Node node) {
-        Iterator<Label> it = node.getLabels().iterator();
-        if (it.hasNext()) {
-            return ":" + join(":", it);
-        }
-        return "";
-    }
+	public static String getLabelsString(Node node) {
+		Iterator<Label> it = node.getLabels().iterator();
+		if (it.hasNext()) {
+			return ":" + join(":", it);
+		}
+		return "";
+	}
 }


### PR DESCRIPTION
I added the support for array properties to the graphml-import/export commands.
I also slightly modified the graphml-export command so that it does not export node/edge properties with empty values. 

Please note that the diff stats for the java files I modified do not reflect the real changes, which are smaller than indicated. 
This is due to the fact that I copied the new files over the old ones instead of modifying them directly (unfortunately, at the beginning I didn't not think of pulling requests).
Anyway, I marked the changes I made with my nickname (gquercini).
