### PR TITLE
Maintenance updates

### DIFF
--- a/examples/in.csv
+++ b/examples/in.csv
@@ -1,5 +1,0 @@
-name	age
-Michael	38
-Selina	15
-Rana	8
-Selma	5

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>2.0.4</neo4j.version>
+        <neo4j.version>2.1.5</neo4j.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>
@@ -27,16 +27,32 @@
 
     <repositories>
         <repository>
-            <id>neo4j</id>
-            <url>http://m2.neo4j.org/content/repositories/snapshots/</url>
-            <snapshots><enabled>true</enabled></snapshots>
+            <id>neo4j-contrib-releases</id>
+            <url>https://raw.github.com/neo4j-contrib/m2/master/releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>neo4j-contrib-snapshots</id>
+            <url>https://raw.github.com/neo4j-contrib/m2/master/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.mapdb</groupId>
             <artifactId>mapdb</artifactId>
-            <version>0.9.3</version>
+            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>net.sf.opencsv</groupId>
@@ -103,6 +119,16 @@
             <version>${neo4j.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+          <version>1.9.7</version>
+        </dependency>
+        <dependency>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+          <version>2.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/neo4j/shell/tools/imp/ImportCypherApp.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/ImportCypherApp.java
@@ -9,7 +9,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.shell.*;
 import org.neo4j.shell.impl.AbstractApp;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.shell.tools.imp.util.Config;
 import org.neo4j.shell.tools.imp.util.*;
 
 import java.io.*;
@@ -200,7 +199,7 @@ public class ImportCypherApp extends AbstractApp {
 
     private Map<String, Object> createParams(CSVReader reader) throws IOException {
         String[] header = reader.readNext();
-        Map<String,Object> params=new LinkedHashMap<String,Object>();
+        Map<String,Object> params=new LinkedHashMap<>();
         for (String name : header) {
             params.put(name,null);
         }

--- a/src/main/java/org/neo4j/shell/tools/imp/format/CsvFormat.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/CsvFormat.java
@@ -14,7 +14,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.*;
 
-import static org.neo4j.helpers.collection.Iterables.join;
 import static org.neo4j.shell.tools.imp.util.MetaInformation.collectPropTypesForNodes;
 import static org.neo4j.shell.tools.imp.util.MetaInformation.collectPropTypesForRelationships;
 import static org.neo4j.shell.tools.imp.util.MetaInformation.getLabelsString;
@@ -48,7 +47,7 @@ public class CsvFormat implements Format {
     }
 
     private Collection<String> generateHeader(Map<String,Class> nodePropTypes, String...starters) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         Collections.addAll(result, starters);
         for (Map.Entry<String, Class> entry : nodePropTypes.entrySet()) {
             String type = MetaInformation.typeFor(entry.getValue(), null);

--- a/src/main/java/org/neo4j/shell/tools/imp/format/SimpleGraphMLFormat.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/SimpleGraphMLFormat.java
@@ -10,8 +10,6 @@ import org.neo4j.shell.tools.imp.util.Reporter;
 import java.io.Reader;
 import java.io.Writer;
 
-import static org.neo4j.helpers.collection.Iterables.join;
-
 /**
  * @author mh
  * @since 21.01.14

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
 
-import static org.neo4j.helpers.collection.Iterables.join;
 import static org.neo4j.shell.tools.imp.util.MetaInformation.getLabelsString;
 
 /**

--- a/src/main/java/org/neo4j/shell/tools/imp/util/BatchTransaction.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/BatchTransaction.java
@@ -3,7 +3,6 @@ package org.neo4j.shell.tools.imp.util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.TransactionBuilder;
 
 /**
 * @author mh

--- a/src/main/java/org/neo4j/shell/tools/imp/util/Config.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/Config.java
@@ -23,7 +23,7 @@ public class Config {
 
     public static String extractQuery(AppCommandParser parser) {
         String line = parser.getLineWithoutApp().trim();
-        Map<String, String> options = new HashMap<String, String>(parser.options());
+        Map<String, String> options = new HashMap<>(parser.options());
         while (!options.isEmpty() && line.startsWith("-")) {
             String option = options.remove(line.substring(1, 2));
             int offset = option!=null ? 3 + option.length() : 2;

--- a/src/main/java/org/neo4j/shell/tools/imp/util/WriterOutputStream.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/WriterOutputStream.java
@@ -2,9 +2,7 @@ package org.neo4j.shell.tools.imp.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PipedOutputStream;
 import java.io.Writer;
-import java.nio.charset.Charset;
 
 /**
  * @author mh

--- a/src/test/java/org/neo4j/shell/tools/imp/GraphMLReaderTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/GraphMLReaderTest.java
@@ -15,7 +15,6 @@ import java.io.InputStreamReader;
 import java.io.StringReader;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Created by mh on 10.07.13.

--- a/src/test/java/org/neo4j/shell/tools/imp/ImportCypherAppTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ImportCypherAppTest.java
@@ -90,6 +90,7 @@ public class ImportCypherAppTest {
         }
     }
 
+    @Ignore("Testfile 'import.csv' missing in git")
     @Test
     public void testRunWithInputFile2() throws Exception {
         assertCommand(client, "import-cypher -d \"\\t\" -i import.csv create (n {name:{Trackmbid}}) return n.name as name",

--- a/src/test/java/org/neo4j/shell/tools/imp/ImportCypherPerformanceTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ImportCypherPerformanceTest.java
@@ -14,7 +14,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.io.*;
 import java.rmi.RemoteException;
 import java.util.Collections;
-import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;

--- a/src/test/java/org/neo4j/shell/tools/imp/ImportGeoffAppTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ImportGeoffAppTest.java
@@ -13,7 +13,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.io.*;
 import java.rmi.RemoteException;
 import java.util.Collections;
-import java.util.Scanner;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
- Update Neo4j 2.0.4 -> 2.1.5
- Update MapDB 0.9.3 -> 1.0.6
- Make directly used transitive deps on commons-lang & jackson explicit
- Fix repository for geoff dep.
- Remove unused sample file
- Disable test using a missing test file
- Some diamond operators and unused imports along the way
