### PR TITLE
Add -s option to skip writing CSV headers in ImportCypher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Then choose a suitable import command, depending on how your data is structured.
 
 The auto index command is used to automatically create indexes on certain properties defined on nodes or relationships. This is in addition to the properties defined in 'conf/neo4j.properties'.
 
-`auto-index [-t Node|Relationship] [-r] name age title` 
+`auto-index [-t Node|Relationship] [-r] name age title`
 
 - -r stops indexing those properties
 
@@ -63,6 +63,7 @@ Populate your database with [write clauses](http://docs.neo4j.org/chunked/milest
 - -q: input/output file with quotes
 - -d delim: delim used to separate files (e.g. `-d " ", -d \t -d ,` )
 - -b size: batch size for intermediate commits
+- -s: skip writing headers when writing output to a csv file
 
 Example input file: [in.csv](examples/in.csv)
 

--- a/src/main/java/org/neo4j/shell/tools/imp/util/Config.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/Config.java
@@ -20,6 +20,7 @@ public class Config {
     private String delim = DEFAULT_DELIM;
     private boolean quotes;
     private boolean types = false;
+    private boolean writeHeaders = true;
 
     public static String extractQuery(AppCommandParser parser) {
         String line = parser.getLineWithoutApp().trim();
@@ -59,6 +60,10 @@ public class Config {
         return types;
     }
 
+    public boolean writeHeaders() {
+        return writeHeaders;
+    }
+
     public static Config fromOptions(AppCommandParser parser) {
         Config config = new Config();
         config.silent = parser.options().containsKey("s");
@@ -66,6 +71,7 @@ public class Config {
         config.delim = delim(parser.option("d", String.valueOf(DEFAULT_DELIM)));
         config.quotes = parser.options().containsKey("q");
         config.types = parser.options().containsKey("t");
+        config.writeHeaders = !parser.options().containsKey("s");
         return config;
     }
 

--- a/src/test/java/org/neo4j/shell/tools/imp/ImportCypherAppTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ImportCypherAppTest.java
@@ -182,6 +182,19 @@ public class ImportCypherAppTest {
         }
     }
 
+    @Test
+    public void testRunWithOutputFileAndSkipHeaders() throws Exception {
+        assertCommand(client, "import-cypher -o out.csv -s start x=node(0,0) create n return id(n) as id",
+                "Query: start x=node(0,0) create n return id(n) as id infile (none) delim ',' quoted false outfile out.csv batch-size 1000 skip-headers true",
+                "Import statement execution created 2 rows of output.");
+        assertFile("1","2");
+        try (Transaction tx = db.beginTx()) {
+            assertNotNull(db.getNodeById(1));
+            assertNotNull(db.getNodeById(2));
+            tx.success();
+        }
+    }
+
     private void assertFile(String...expected) throws FileNotFoundException {
         File file = new File("out.csv");
         assertTrue("outfile exits",file.exists());


### PR DESCRIPTION
I added an option to not write CSV headers to the output file. Also changed boolean "first" to "writeHeaders" to be more explicit. Also added a test for it.

This came from a need I have while doing some development with Apache Spark where it's quite useful to read CSV/TSV files without headers.
