### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/org/neo4j/shell/tools/imp/format/MultiStatementCypherSubGraphExporter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/MultiStatementCypherSubGraphExporter.java
@@ -48,6 +48,10 @@ public class MultiStatementCypherSubGraphExporter {
     private final static String UNIQUE_ID_PROP = "UNIQUE IMPORT ID";
     private long artificialUniques = 0;
 
+    private final NumberFormat decimalFormat = new DecimalFormat() {{
+        setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.US));
+    }};
+
     public MultiStatementCypherSubGraphExporter(SubGraph graph) {
         this.graph = graph;
         uniqueConstraints = gatherUniqueConstraints(indexNames, indexedProperties);
@@ -300,10 +304,6 @@ public class MultiStatementCypherSubGraphExporter {
         }
         return "[" + result.toString() + "]";
     }
-
-    private final NumberFormat decimalFormat = new DecimalFormat() {{
-	   setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.US));
-    }};
 
     private String toString(Object value) {
         if (value == null) return "null";

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
@@ -29,6 +29,20 @@ public class XmlGraphMLReader {
     private Reporter reporter;
     private boolean labels;
 
+    public static final QName ID = QName.valueOf("id");
+    public static final QName LABELS = QName.valueOf("labels");
+    public static final QName SOURCE = QName.valueOf("source");
+    public static final QName TARGET = QName.valueOf("target");
+    public static final QName LABEL = QName.valueOf("label");
+    public static final QName FOR = QName.valueOf("for");
+    public static final QName NAME = QName.valueOf("attr.name");
+    public static final QName TYPE = QName.valueOf("attr.type");
+    public static final QName KEY = QName.valueOf("key");
+
+    public XmlGraphMLReader(GraphDatabaseService gdb) {
+        this.gdb = gdb;
+    }
+
     public XmlGraphMLReader storeNodeIds() {
         this.storeNodeIds = true;
         return this;
@@ -118,20 +132,6 @@ public class XmlGraphMLReader {
             if (input == null || input.trim().isEmpty()) return defaultValue;
             return type.parse(input);
         }
-    }
-
-    public static final QName ID = QName.valueOf("id");
-    public static final QName LABELS = QName.valueOf("labels");
-    public static final QName SOURCE = QName.valueOf("source");
-    public static final QName TARGET = QName.valueOf("target");
-    public static final QName LABEL = QName.valueOf("label");
-    public static final QName FOR = QName.valueOf("for");
-    public static final QName NAME = QName.valueOf("attr.name");
-    public static final QName TYPE = QName.valueOf("attr.type");
-    public static final QName KEY = QName.valueOf("key");
-
-    public XmlGraphMLReader(GraphDatabaseService gdb) {
-        this.gdb = gdb;
     }
 
     public long parseXML(Reader input, NodeCache cache) throws XMLStreamException {

--- a/src/main/java/org/neo4j/shell/tools/imp/util/MetaInformation.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/MetaInformation.java
@@ -16,6 +16,7 @@ import static org.neo4j.helpers.collection.Iterables.join;
  * @since 19.01.14
  */
 public class MetaInformation {
+    public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));
 
     public static Map<String,Class> collectPropTypesForNodes(SubGraph graph) {
         Map<String,Class> propTypes = new LinkedHashMap<>();
@@ -44,8 +45,6 @@ public class MetaInformation {
             keyTypes.put(prop, void.class);
         }
     }
-
-    public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));
 
     public static String typeFor(Class value, Set<String> allowed) {
         if (value == void.class) return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat
