### PR TITLE
squid:S2325 -  private methods that don't access instance data should…

### DIFF
--- a/src/main/java/org/neo4j/shell/tools/imp/ImportCsvApp.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/ImportCsvApp.java
@@ -83,12 +83,12 @@ public class ImportCsvApp extends AbstractApp {
         return Continuation.INPUT_COMPLETE;
     }
 
-    private String name(Object file) {
+    private static String name(Object file) {
         if (file==null) return "(none)";
         return file.toString();
     }
 
-    private char delim(String value) {
+    private static char delim(String value) {
         if (value.length()==1) return value.charAt(0);
         if (value.contains("\\t")) return '\t';
         if (value.contains(" ")) return ' ';
@@ -131,7 +131,7 @@ public class ImportCsvApp extends AbstractApp {
         return outCount;
     }
 
-    private Map<String, Type> extractTypes(Map<String, Object> params) {
+    private static Map<String, Type> extractTypes(Map<String, Object> params) {
         Map<String,Object> newParams = new LinkedHashMap<>();
         Map<String,Type> types = new LinkedHashMap<>();
         for (String header : params.keySet()) {
@@ -149,7 +149,7 @@ public class ImportCsvApp extends AbstractApp {
         return types;
     }
 
-    private String applyReplacements(String query, Map<String, String> replacements, Map<String, Object> queryParams) {
+    private static String applyReplacements(String query, Map<String, String> replacements, Map<String, Object> queryParams) {
         for (Map.Entry<String, String> entry : replacements.entrySet()) {
             Object value = queryParams.get(entry.getKey());
             query = query.replace(entry.getValue(), String.valueOf(value));
@@ -157,7 +157,7 @@ public class ImportCsvApp extends AbstractApp {
         return query;
     }
 
-    private Map<String, String> computeReplacements(Map<String, Object> params, String query) {
+    private static Map<String, String> computeReplacements(Map<String, Object> params, String query) {
         Map<String, String> result = new HashMap<>();
         for (String name : params.keySet()) {
             String pattern = "#{" + name + "}";
@@ -219,7 +219,7 @@ public class ImportCsvApp extends AbstractApp {
         writer.writeNext(data);
     }
 
-    private String toString(Map<String, Object> row, String col) {
+    private static String toString(Map<String, Object> row, String col) {
         Object value = row.get(col);
         return value == null ? null : value.toString();
     }
@@ -233,7 +233,7 @@ public class ImportCsvApp extends AbstractApp {
         return params;
     }
 
-    private Map<String, Object> update(Map<String, Object> params, Map<String, Type> types, String[] input) {
+    private static Map<String, Object> update(Map<String, Object> params, Map<String, Type> types, String[] input) {
         int col=0;
         for (Map.Entry<String, Object> param : params.entrySet()) {
             Type type = types.get(param.getKey());

--- a/src/main/java/org/neo4j/shell/tools/imp/ImportCypherApp.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/ImportCypherApp.java
@@ -83,12 +83,12 @@ public class ImportCypherApp extends AbstractApp {
         return Continuation.INPUT_COMPLETE;
     }
 
-    private String name(Object file) {
+    private static String name(Object file) {
         if (file==null) return "(none)";
         return file.toString();
     }
 
-    private char delim(String value) {
+    private static char delim(String value) {
         if (value.length()==1) return value.charAt(0);
         if (value.contains("\\t")) return '\t';
         if (value.contains(" ")) return ' ';
@@ -133,7 +133,7 @@ public class ImportCypherApp extends AbstractApp {
         return outCount;
     }
 
-    private Map<String, Type> extractTypes(Map<String, Object> params) {
+    private static Map<String, Type> extractTypes(Map<String, Object> params) {
         Map<String,Object> newParams = new LinkedHashMap<>();
         Map<String,Type> types = new LinkedHashMap<>();
         for (String header : params.keySet()) {
@@ -151,7 +151,7 @@ public class ImportCypherApp extends AbstractApp {
         return types;
     }
 
-    private String applyReplacements(String query, Map<String, String> replacements, Map<String, Object> queryParams) {
+    private static String applyReplacements(String query, Map<String, String> replacements, Map<String, Object> queryParams) {
         for (Map.Entry<String, String> entry : replacements.entrySet()) {
             Object value = queryParams.get(entry.getKey());
             query = query.replace(entry.getValue(), String.valueOf(value));
@@ -159,7 +159,7 @@ public class ImportCypherApp extends AbstractApp {
         return query;
     }
 
-    private Map<String, String> computeReplacements(Map<String, Object> params, String query) {
+    private static Map<String, String> computeReplacements(Map<String, Object> params, String query) {
         Map<String, String> result = new HashMap<>();
         for (String name : params.keySet()) {
             String pattern = "#{" + name + "}";
@@ -194,7 +194,7 @@ public class ImportCypherApp extends AbstractApp {
         writer.writeNext(data);
     }
 
-    private String toString(Map<String, Object> row, String col) {
+    private static String toString(Map<String, Object> row, String col) {
         Object value = row.get(col);
         if (value instanceof Double) {
             value = String.format("%.2f", value);
@@ -211,7 +211,7 @@ public class ImportCypherApp extends AbstractApp {
         return params;
     }
 
-    private Map<String, Object> update(Map<String, Object> params, Map<String, Type> types, String[] input) {
+    private static Map<String, Object> update(Map<String, Object> params, Map<String, Type> types, String[] input) {
         int col=0;
         for (Map.Entry<String, Object> param : params.entrySet()) {
             Type type = types.get(param.getKey());

--- a/src/main/java/org/neo4j/shell/tools/imp/format/CsvFormat.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/CsvFormat.java
@@ -47,7 +47,7 @@ public class CsvFormat implements Format {
         }
     }
 
-    private Collection<String> generateHeader(Map<String,Class> nodePropTypes, String...starters) {
+    private static Collection<String> generateHeader(Map<String,Class> nodePropTypes, String...starters) {
         List<String> result = new ArrayList<String>();
         Collections.addAll(result, starters);
         for (Map.Entry<String, Class> entry : nodePropTypes.entrySet()) {

--- a/src/main/java/org/neo4j/shell/tools/imp/format/MultiStatementCypherSubGraphExporter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/MultiStatementCypherSubGraphExporter.java
@@ -151,7 +151,7 @@ public class MultiStatementCypherSubGraphExporter {
         return "CREATE INDEX ON :" + quote(label) + "(" + quote(key) + ");";
     }
 
-    private String uniqueConstraint(String label, String key) {
+    private static String uniqueConstraint(String label, String key) {
         return "CREATE CONSTRAINT ON (node:" + quote(label) + ") ASSERT node." + quote(key) + " IS UNIQUE;";
     }
 

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/SimpleGraphMLWriter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/SimpleGraphMLWriter.java
@@ -49,7 +49,7 @@ public class SimpleGraphMLWriter {
         writeKeyTypes(writer, keyTypes, "edge");
     }
 
-    private void writeKeyTypes(Writer writer, Map<String, Class> keyTypes, String forType) throws IOException {
+    private static void writeKeyTypes(Writer writer, Map<String, Class> keyTypes, String forType) throws IOException {
         for (Map.Entry<String, Class> entry : keyTypes.entrySet()) {
             String type = MetaInformation.typeFor(entry.getValue(), MetaInformation.GRAPHML_ALLOWED);
             if (type == null) continue;
@@ -116,16 +116,16 @@ public class SimpleGraphMLWriter {
         return count;
     }
 
-    private void writeData(Writer writer, String prop, Object value) throws IOException {
+    private static void writeData(Writer writer, String prop, Object value) throws IOException {
         writer.write("<data key=\""+prop+"\">"+value+"</data>");
     }
 
-    private void writeFooter(Writer writer) throws IOException {
+    private static void writeFooter(Writer writer) throws IOException {
         writer.write("</graph>\n" +
                 "</graphml>");
     }
 
-    private void writeHeader(Writer writer) throws IOException {
+    private static void writeHeader(Writer writer) throws IOException {
         writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"\n" +
                 " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLReader.java
@@ -234,7 +234,7 @@ public class XmlGraphMLReader {
         }
     }
 
-    private XMLEvent peek(XMLEventReader reader) throws XMLStreamException {
+    private static XMLEvent peek(XMLEventReader reader) throws XMLStreamException {
         XMLEvent peek = reader.peek();
         if (peek.isCharacters() && (peek.asCharacters().isWhiteSpace())) {
             reader.nextEvent();
@@ -243,7 +243,7 @@ public class XmlGraphMLReader {
         return peek;
     }
 
-    private void setDefaults(Map<String, Key> keys, PropertyContainer pc) {
+    private static void setDefaults(Map<String, Key> keys, PropertyContainer pc) {
         if (keys.isEmpty()) return;
         for (Key key : keys.values()) {
             if (key.defaultValue!=null) pc.setProperty(key.name,key.defaultValue);

--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
@@ -91,7 +91,7 @@ public class XmlGraphMLWriter {
         return "n" + node.getId();
     }
 
-    private void writeLabels(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
+    private static void writeLabels(XMLStreamWriter writer, Node node) throws IOException, XMLStreamException {
         String labelsString = getLabelsString(node);
         if (!labelsString.isEmpty()) writer.writeAttribute("labels", labelsString);
     }
@@ -160,7 +160,7 @@ public class XmlGraphMLWriter {
         newLine(writer);
     }
 
-    private void newLine(XMLStreamWriter writer) throws XMLStreamException {
+    private static void newLine(XMLStreamWriter writer) throws XMLStreamException {
         writer.writeCharacters("\n");
     }
 }

--- a/src/main/java/org/neo4j/shell/tools/imp/util/QueryParameterExtractor.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/util/QueryParameterExtractor.java
@@ -27,7 +27,7 @@ public class QueryParameterExtractor {
         return sb.toString();
     }
 
-    private Object convertValue(String value) {
+    private static Object convertValue(String value) {
         if (value.equals("NULL") || value.equals("null")) return null;
         if (value.charAt(0)=='"' || value.charAt(0)=='\'') {
             return value.substring(1, value.length() - 1);
@@ -46,7 +46,7 @@ public class QueryParameterExtractor {
         }
     }
 
-    private String param(int i) {
+    private static String param(int i) {
         return " p "+i;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat
