### PR TITLE
fix location of <key> elements in graphml export

### DIFF
--- a/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
+++ b/src/main/java/org/neo4j/shell/tools/imp/format/graphml/XmlGraphMLWriter.java
@@ -28,6 +28,7 @@ public class XmlGraphMLWriter {
         XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);
         writeHeader(xmlWriter);
         if (config.useTypes()) writeKeyTypes(xmlWriter, graph);
+        writeGraph(xmlWriter);
         for (Node node : graph.getNodes()) {
             int props = writeNode(xmlWriter, node);
             reporter.update(1, 0, props);
@@ -162,6 +163,9 @@ public class XmlGraphMLWriter {
         writer.writeAttribute("xmlns", "http://graphml.graphdrawing.org/xmlns", "xsi", "http://www.w3.org/2001/XMLSchema-instance");
         writer.writeAttribute("xsi", "", "schemaLocation", "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd");
         newLine(writer);
+    }
+
+    private void writeGraph(XMLStreamWriter writer) throws IOException, XMLStreamException {
         writer.writeStartElement("graph");
         writer.writeAttribute("id", "G");
         writer.writeAttribute("edgedefault", "directed");

--- a/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
@@ -31,11 +31,12 @@ public class ExportXmlGraphMLWriterTest {
     static final DynamicRelationshipType TYPE = DynamicRelationshipType.withName("BAR");
     static final String TEST_XML_HEADER =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n" +
-            "<graph id=\"G\" edgedefault=\"directed\">\n";
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
     static final String TEST_XML_KEYS =
             "<key id=\"na&lt;&gt;me\" for=\"node\" attr.name=\"na&lt;&gt;me\" attr.type=\"string\"/>\n" +
             "<key id=\"count\" for=\"edge\" attr.name=\"count\" attr.type=\"double\"/>\n";
+    static final String TEST_XML_GRAPH = 
+            "<graph id=\"G\" edgedefault=\"directed\">\n";
     public static final String TEST_XML_DATA_NODE =
             "<node id=\"n0\" labels=\":FOO\"><data key=\"labels\">:FOO</data><data key=\"na&lt;&gt;me\">John &amp; Dö</data></node>\n";
     public static final String TEST_XML_DATA_EDGE =
@@ -80,7 +81,7 @@ public class ExportXmlGraphMLWriterTest {
         ProgressReporter reporter = new ProgressReporter(null, null);
         String xml = doExport(reporter, false);
         assertEquals(new ElementCounter().update(1, 1, 2), reporter.getTotal());
-        assertEquals(TEST_XML_HEADER+TEST_XML_DATA+TEST_XML_FOOTER,xml);
+        assertEquals(TEST_XML_HEADER+TEST_XML_GRAPH+TEST_XML_DATA+TEST_XML_FOOTER,xml);
     }
 
     @Test
@@ -89,7 +90,7 @@ public class ExportXmlGraphMLWriterTest {
         ProgressReporter reporter = new ProgressReporter(null, null);
         String xml = doExport(reporter,true);
         assertEquals(new ElementCounter().update(1, 1, 2), reporter.getTotal());
-        assertEquals(TEST_XML_HEADER+TEST_XML_KEYS+TEST_XML_DATA+TEST_XML_FOOTER,xml);
+        assertEquals(TEST_XML_HEADER+TEST_XML_GRAPH+TEST_XML_KEYS+TEST_XML_DATA+TEST_XML_FOOTER,xml);
     }
 
     private void createData(int nodes) {

--- a/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
@@ -31,11 +31,12 @@ public class ExportXmlGraphMLWriterTest {
     static final DynamicRelationshipType TYPE = DynamicRelationshipType.withName("BAR");
     static final String TEST_XML_HEADER =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n" +
-            "<graph id=\"G\" edgedefault=\"directed\">\n";
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
     static final String TEST_XML_KEYS =
             "<key id=\"na&lt;&gt;me\" for=\"node\" attr.name=\"na&lt;&gt;me\" attr.type=\"string\"/>\n" +
             "<key id=\"count\" for=\"edge\" attr.name=\"count\" attr.type=\"double\"/>\n";
+    static final String TEST_XML_GRAPH = 
+            "<graph id=\"G\" edgedefault=\"directed\">\n";
     public static final String TEST_XML_DATA_NODE =
             "<node id=\"n0\" labels=\":FOO\"><data key=\"labels\">:FOO</data><data key=\"na&lt;&gt;me\">John &amp; Dö</data></node>\n";
     public static final String TEST_XML_DATA_EDGE =

--- a/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
+++ b/src/test/java/org/neo4j/shell/tools/imp/ExportXmlGraphMLWriterTest.java
@@ -81,7 +81,7 @@ public class ExportXmlGraphMLWriterTest {
         ProgressReporter reporter = new ProgressReporter(null, null);
         String xml = doExport(reporter, false);
         assertEquals(new ElementCounter().update(1, 1, 2), reporter.getTotal());
-        assertEquals(TEST_XML_HEADER+TEST_XML_DATA+TEST_XML_FOOTER,xml);
+        assertEquals(TEST_XML_HEADER+TEST_XML_GRAPH+TEST_XML_DATA+TEST_XML_FOOTER,xml);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ExportXmlGraphMLWriterTest {
         ProgressReporter reporter = new ProgressReporter(null, null);
         String xml = doExport(reporter,true);
         assertEquals(new ElementCounter().update(1, 1, 2), reporter.getTotal());
-        assertEquals(TEST_XML_HEADER+TEST_XML_KEYS+TEST_XML_DATA+TEST_XML_FOOTER,xml);
+        assertEquals(TEST_XML_HEADER+TEST_XML_GRAPH+TEST_XML_KEYS+TEST_XML_DATA+TEST_XML_FOOTER,xml);
     }
 
     private void createData(int nodes) {


### PR DESCRIPTION
See Issue #103 

I think this might be the only change necessary to put the `<key>`s in the correct location. It also looks like the Reader class should be able to read it back in just fine. 

I haven't built or tested this myself, yet, I'm not really set up for Java work. 

Any input is appreciated. I'm using another library to consume this GraphML and this bug is actually breaking the other library.