### PR TITLE
Update to 3.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ target
 .idea
 .DS_Store
 *.geoff
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>3.1.0-M04</neo4j.version>
+        <neo4j.version>3.1.1</neo4j.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.neo4j.shell</groupId>
     <artifactId>import-tools</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <name>neo4j-shell-import-tools</name>
 
     <build>

--- a/readme.md
+++ b/readme.md
@@ -7,29 +7,29 @@
 Download [neo4j-shell-tools_3.0.1.zip](http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip) and extract it in your
 Neo4j Server's lib directory e.g.
 
-````
-cd /path/to/neo4j-community-3.0.1.
+```
+cd /path/to/neo4j-community-3.0.1
 curl http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip -o neo4j-shell-tools.zip
 unzip neo4j-shell-tools.zip -d lib
-````
+```
 
 #### Easier installation on Unix
 
 The following script does the above installation automatically, and sets the `$NEO4J_HOME` path; works on Unix:
 
-````
+```
 NEO4J_HOME=$(neo4j-shell -c 'dbinfo -g Kernel StoreDirectory' | grep -oE '\/.*lib.*?\/') && curl -Lk -o neo4j-shell-tools.zip http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip && unzip neo4j-shell-tools.zip -d ${NEO4J_HOME}lib
-````
+```
 
 ### Before you start
 
 Restart neo4j and then launch the neo4j-shell:
 
-````
+```
 cd /path/to/neo4j-community-3.0.1
 ./bin/neo4j restart
 ./bin/neo4j-shell
-````
+```
 
 That assumes a default neo4j instance running on port 7474. You can call `./bin/neo4j-shell --help` to get a list of other ways to connect to a neo4j instance.
 
@@ -38,10 +38,10 @@ That assumes a default neo4j instance running on port 7474. You can call `./bin/
 Before importing data, make sure that you create the necessary [indexes or constraints](http://neo4j.com/docs/stable/cypher-schema.html) for your data, so that you can quickly access the starting points for your graph patterns afterwards.
 For instance:
 
-````
+```
 create constraint on (p:Person) assert p.email is unique;
 create index on :Person(age);
-````
+```
 
 
 ### Import
@@ -56,7 +56,9 @@ Then choose a suitable import command, depending on how your data is structured.
 
 Populate your database with [write clauses](http://neo4j.com/docs/stable/query-write.html) in the [cypher](http://neo4j.com/docs/stable/cypher-query-lang.html) query language.
 
-`import-cypher [-i in.csv] [-o out.csv] [-d ,] [-q] [-b 10000] create (n:#{label} {name: {name}, age: {age}}) return id(n) as id, n.name as name`
+```
+$ import-cypher [-i in.csv] [-o out.csv] [-d ,] [-q] [-b 10000] create (n:#{label} {name: {name}, age: {age}}) return id(n) as id, n.name as name
+```
 
 - -i file.csv: tab or comma separated input data file (or URL), with header. Header names are used as param-names. The cypher  statement will be executed one per row
 - -o file.csv: tab or comma separated output data file, all cypher result rows will be written to file, column labels become headers
@@ -66,73 +68,77 @@ Populate your database with [write clauses](http://neo4j.com/docs/stable/query-w
 
 Example input file: [in.csv](examples/in.csv)
 
-````
+```
 name	age
 Michael	38
 Selina	15
 Rana	8
 Selma	5
-````
+```
 
 Usage:
 
-````
+```
 $ import-cypher -d"\t" -i in.csv -o out.csv create (n {name: {name}, age: {age}}) return id(n) as id, n.name as name
 Query: create (n {name: {name}, age: {age}}) return id(n) as id, n.name as name; infile in.csv delim '	' quoted false outfile out.csv batch-size 20000
 Import statement execution created 4 rows of output.
-````
+```
 
 Output file: out.csv
 
-````
+```
 id	name
 1	Michael
 2	Selina
 3	Rana
 4	Selma
-````
+```
 
 Optionally support types for column headers: just use `prop:type` as header in your csv, e.g. `name:string,age:int`
 
 Supported Types
 
-* int
-* long
-* double
-* float
-* boolean
-* string
-* byte
-* and arrays thereof with <type>_array, e.g. int_array
+* `int`
+* `long`
+* `double`
+* `float`
+* `boolean`
+* `string`
+* `byte`
+* and arrays thereof with `<type>_array`, e.g. `int_array`
 
 #### Geoff Import
 
 Populate your database with [geoff](http://nigelsmall.com/geoff) - a declarative notation for representing graph data in a human-readable format.
 
-`import-geoff [-i in.geoff]`
+```
+$ import-geoff [-i in.geoff]
+```
 
 - -i in.geoff: newline separated geoff rule file (or URL)
 
 Example input file: in.geoff
 
-````
+```
 (A) {"name": "Alice"}
 (B) {"name": "Bob"}
 (A)-[r:KNOWS]->(B)
-````
+```
 
 Usage:
 
-````
+```
 $ import-geoff -i in.geoff
 Geoff import of in.geoff created 3 entities.
-````
+```
 
 #### Binary Import
 
 Populate your database from a binary dump of a neo4j database.  Internally, Kyro is used to serialize the graph.
 
-`import-binary [-i in.bin] [-r REL_TYPE] [-b 20000] [-c]`
+```
+$ import-binary [-i in.bin] [-r REL_TYPE] [-b 20000] [-c]
+```
 
 - -i in.bin: binary file from previous database export
 - -r REL_TYPE default relationship-type for relationships without a label attribute
@@ -141,15 +147,17 @@ Populate your database from a binary dump of a neo4j database.  Internally, Kyro
 
 Usage:
 
-````
+```
 $ import-binary -b 10000 -i /tmp/export.bin -c
-````
+```
 
 #### GraphML Import
 
 Populate your database from [GraphML](http://graphml.graphdrawing.org/) files. GraphML is an XML file format used to describe graphs.
 
-`import-graphml [-i in.xml] [-r REL_TYPE] [-b 20000] [-c] [-t]`
+```
+$ import-graphml [-i in.xml] [-r REL_TYPE] [-b 20000] [-c] [-t]
+```
 
 - -i in.xml: graphml file (or URL)
 - -r REL_TYPE default relationship-type for relationships without a label attribute
@@ -159,7 +167,7 @@ Populate your database from [GraphML](http://graphml.graphdrawing.org/) files. G
 
 Example input file: in.xml
 
-````xml
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -179,17 +187,17 @@ Example input file: in.xml
         </edge>
     </graph>
 </graphml>
-````
+```
 
 Usage:
 
-````
+```
 $ import-graphml -i in.xml
 GraphML-Import file in.xml rel-type RELATED_TO batch-size 40000 use disk-cache false
 0. 100%: nodes = 1 rels = 0 properties = 0 time 11 ms
 Finished: nodes = 2 rels = 1 properties = 2 total time 16 ms
 GraphML import created 3 entities.
-````
+```
 
 ### Export
 
@@ -206,24 +214,26 @@ If you have a populated database, you can dump it completely or partially (by us
 
 The export order is:
 
-. Nodes batched in transactions
-. Schema information like indexes and constraints
-. Relationships by looking up nodes by primary keys and connecting them, also batched in transactions
+1. Nodes batched in transactions
+1. Schema information like indexes and constraints
+1. Relationships by looking up nodes by primary keys and connecting them, also batched in transactions
 
-`export-cypher [-o export.cypher] [-r] [-b 10000] [MATCH (p:Person)-[r:ACTED_IN]->(m:Movie) RETURN *]`
+```
+$ export-cypher [-o export.cypher] [-r] [-b 10000] [MATCH (p:Person)-[r:ACTED_IN]->(m:Movie) RETURN *]
+```
 
 - -o file.cypher: output file for dump, if left blank the output is sent to the neo4j-shell output and has to be redirected
 - -b size: batch size for commit batches for nodes and relationships
 - -r add all nodes of selected relationships, also add relationships between selected nodes
 
-**Note:** 
+**Note:**
 For nodes that don't have a unique constraint, a temporary label (`UNIQUE IMPORT LABEL`) and property (`UNIQUE IMPORT ID`) are added to allow later lookup in the relationship-generation section.
 A constraint for `UNIQUE IMPORT LABEL`(`UNIQUE IMPORT ID`) is added too. All, the constraint, the label and the property are removed at the end of the import script again.
 
 Example dump file:
 
-````
-export-cypher -r -o test.cypher match (n)-[r]->() return n,r
+```
+$ export-cypher -r -o test.cypher match (n)-[r]->() return n,r
 
 // create nodes
 begin
@@ -251,27 +261,31 @@ commit
 begin
 DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
 commit
-````
+```
 
 #### Binary Export
 
 Export your Neo4j graph database to a binary file.
 
-`export-binary -o out.bin`
+```
+$ export-binary -o out.bin
+```
 
 - -o out.bin
 
 Usage:
 
-````
+```
 $ export-binary -o out.bin
-````
+```
 
 #### GraphML Export
 
 Export your Neo4j graph database to [GraphML](http://graphml.graphdrawing.org/) files. GraphML is an XML file format used to describe graphs. Can be used to import and visualize your graph in [Gephi](http://gephi.org).
 
-`export-graphml [-o out.graphml] [-t] [-r] [match (n:Foo)-[r]->() return n,r]`
+```
+$ export-graphml [-o out.graphml] [-t] [-r] [match (n:Foo)-[r]->() return n,r]
+```
 
 - -o out.graphml: graphml file to write to
 - -t write types, do a first pass over the data to determine property-types and write them to the graphml header
@@ -280,7 +294,7 @@ Export your Neo4j graph database to [GraphML](http://graphml.graphdrawing.org/) 
 
 Example output file: out.graphml
 
-````xml
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -295,14 +309,13 @@ Example output file: out.graphml
 <edge id="e1" source="n1" target="n0" label="KNOWS"><data key="label">KNOWS</data><data key="count">1</data></edge>
 </graph>
 </graphml>
-````
+```
 
 Usage:
 
-````
+```
 $ export-graphml -o out.graphml
-
-````
+```
 
 ### Prerequisites
 
@@ -325,17 +338,17 @@ An import of [@chrisdiehl](https://twitter.com/chrisdiehl)'s [Enron Dataset](htt
 
 ### Manual Build & Install
 
-````
+```
 git clone git@github.com:jexp/neo4j-shell-tools.git
 cd neo4j-shell-tools
 mvn clean package dependency:copy-dependencies
-````
+```
 
 Then copy the jars that get generated into the neo4j lib directory:
 
-````
-cp target/import-tools-2.2*.jar target/dependency/opencsv-2.3.jar target/dependency/neo4j-geoff-1.7-SNAPSHOT.jar target/dependency/mapdb-0.9.3.jar /path/to/neo4j-community-2.2.5/lib
-````
+```
+cp target/import-tools-*.jar target/dependency/opencsv-*.jar target/dependency/geoff-*.jar target/dependency/mapdb-*.jar target/dependency/kryo-*.jar target/dependency/reflectasm-*.jar target/dependency/minlog-*.jar target/dependency/objenesis-*.jar /path/to/neo4j-community/lib
+```
 
 or make those two files available on your neo4j-shell classpath
 
@@ -345,13 +358,15 @@ or make those two files available on your neo4j-shell classpath
 
 The auto index command is used to automatically create indexes on certain properties defined on nodes or relationships. This is in addition to the properties defined in 'conf/neo4j.properties'.
 
-`auto-index [-t Node|Relationship] [-r] name age title` 
+```
+auto-index [-t Node|Relationship] [-r] name age title
+```
 
 - -r stops indexing those properties
 
 Usage:
 
-````
+```
 $ auto-index name age title
 Enabling auto-indexing of Node properties: [name, age, title]
-````
+```

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,12 @@
 
 ### Installation
 
-Download [neo4j-shell-tools_3.0.1.zip](http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip) and extract it in your
+Download [neo4j-shell-tools_3.1.0.zip](http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.1.0.zip) and extract it in your
 Neo4j Server's lib directory e.g.
 
 ```
-cd /path/to/neo4j-community-3.0.1
-curl http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip -o neo4j-shell-tools.zip
+cd /path/to/neo4j-community-3.1.0
+curl http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.1.0.zip -o neo4j-shell-tools.zip
 unzip neo4j-shell-tools.zip -d lib
 ```
 
@@ -18,7 +18,7 @@ unzip neo4j-shell-tools.zip -d lib
 The following script does the above installation automatically, and sets the `$NEO4J_HOME` path; works on Unix:
 
 ```
-NEO4J_HOME=$(neo4j-shell -c 'dbinfo -g Kernel StoreDirectory' | grep -oE '\/.*lib.*?\/') && curl -Lk -o neo4j-shell-tools.zip http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.0.1.zip && unzip neo4j-shell-tools.zip -d ${NEO4J_HOME}lib
+NEO4J_HOME=$(neo4j-shell -c 'dbinfo -g Kernel StoreDirectory' | grep -oE '\/.*lib.*?\/') && curl -Lk -o neo4j-shell-tools.zip http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.1.0.zip && unzip neo4j-shell-tools.zip -d ${NEO4J_HOME}lib
 ```
 
 ### Before you start
@@ -26,7 +26,7 @@ NEO4J_HOME=$(neo4j-shell -c 'dbinfo -g Kernel StoreDirectory' | grep -oE '\/.*li
 Restart neo4j and then launch the neo4j-shell:
 
 ```
-cd /path/to/neo4j-community-3.0.1
+cd /path/to/neo4j-community-3.1.0
 ./bin/neo4j restart
 ./bin/neo4j-shell
 ```
@@ -47,14 +47,14 @@ create index on :Person(age);
 ### Import
 
 Then choose a suitable import command, depending on how your data is structured.
-* If your data is formatted as CSV and you want to use [cypher](http://neo4j.com/docs/stable/cypher-query-lang.html) statements for importing it, use the [Cypher Import](#cypher-import) command.
+* If your data is formatted as CSV and you want to use [Cypher](http://neo4j.com/docs/stable/cypher-query-lang.html) statements for importing it, use the [Cypher Import](#cypher-import) command.
 * If your data is in [GraphML](http://graphml.graphdrawing.org/) format, use the [GraphML Import](#graphml-import) command.
 * If your data is in [Geoff](http://nigelsmall.com/geoff) format, use the [Geoff Import](#geoff-import) command.
 * If your data is in Binary format, use the [Binary Import](#binary-import) command.
 
 #### Cypher Import
 
-Populate your database with [write clauses](http://neo4j.com/docs/stable/query-write.html) in the [cypher](http://neo4j.com/docs/stable/cypher-query-lang.html) query language.
+Populate your database with [write clauses](http://neo4j.com/docs/stable/query-write.html) in the [Cypher](http://neo4j.com/docs/stable/cypher-query-lang.html) query language.
 
 ```
 $ import-cypher [-i in.csv] [-o out.csv] [-d ,] [-q] [-b 10000] create (n:#{label} {name: {name}, age: {age}}) return id(n) as id, n.name as name
@@ -109,13 +109,13 @@ Supported Types
 
 #### Geoff Import
 
-Populate your database with [geoff](http://nigelsmall.com/geoff) - a declarative notation for representing graph data in a human-readable format.
+Populate your database with [Geoff](http://nigelsmall.com/geoff) - a declarative notation for representing graph data in a human-readable format.
 
 ```
 $ import-geoff [-i in.geoff]
 ```
 
-- -i in.geoff: newline separated geoff rule file (or URL)
+- -i in.geoff: newline separated Geoff rule file (or URL)
 
 Example input file: in.geoff
 
@@ -326,13 +326,13 @@ An up and running neo4j database which you can [download from here](http://www.n
 #### Libraries used
 * Cypher Import uses [opencsv-2.3.jar](http://opencsv.sourceforge.net/) for parsing CSV files.
 * GraphML Import uses [mapdb-0.9.3.jar](http://www.mapdb.org/) as part of the cache (-c) flag for very large imports
-* Geoff Import uses [neo4j-geoff-1.7-SNAPSHOT.jar](http://nigelsmall.com/geoff)
+* Geoff Import uses [geoff-0.5.0.jar](http://nigelsmall.com/geoff) ([jar](https://github.com/neo4j-contrib/m2/tree/master/releases/com/nigelsmall/geoff/0.5.0))
 
 #### More on GraphML
 
 The 'import-graphml' command supports attributes, supports only single pass parsing, optimization for `parse.nodeids="canonical"`
 
-An import of [@chrisdiehl](https://twitter.com/chrisdiehl)'s [Enron Dataset](http://www.infochimps.com/datasets/enron-email-data-with-manager-subordinate-relationship-metadata) took 5 minutes on a MBA:
+An import of [@chrisdiehl](https://twitter.com/chrisdiehl)'s [Enron Dataset](http://www.cpdiehl.org/2011/01/enron-email-data-and-manager-subordinate-relationship-metadata.html) took 5 minutes on a MBA:
 
 `Finished: nodes = 343266 rels = 1903201 properties = 8888993 total time 313491 ms`
 


### PR DESCRIPTION
Changes:
* Applied the changes of the 3.0 branch to the 3.1 branch.
* Bumped the shell tools and the Neo4j dependency's version to 3.1.1.
* Updated the readme:
  * Changed the link to the `geoff-0.5.0.jar` dependency instead of the `neo4j-geoff-1.7-SNAPSHOT.jar` dependency.
  * Point to http://dist.neo4j.org/jexp/shell/neo4j-shell-tools_3.1.0.zip
  * Changed the broken link to the ENRON dataset to http://www.cpdiehl.org/2011/01/enron-email-data-and-manager-subordinate-relationship-metadata.html as the infochimps page is not available (I am not sure where to find the dataset as a GraphML).

Testing:
* Unit tests run fine.
* I tested the import with the Train Benchmark's [Neo4j implementation](https://github.com/FTSRG/trainbenchmark/blob/4650bd229682715d53c5f952a0040e05eb0193c3/trainbenchmark-tool-neo4j/src/main/java/hu/bme/mit/trainbenchmark/benchmark/neo4j/driver/Neo4jDriver.java#L176) and it worked fine.